### PR TITLE
修改单例工厂类中的bug

### DIFF
--- a/rpc-framework-common/src/main/java/github/javaguide/factory/SingletonFactory.java
+++ b/rpc-framework-common/src/main/java/github/javaguide/factory/SingletonFactory.java
@@ -18,8 +18,9 @@ public final class SingletonFactory {
 
     public static <T> T getInstance(Class<T> c) {
         String key = c.toString();
-        Object instance = OBJECT_MAP.get(key);
+        Object instance = null;
         synchronized (c) {
+            instance =  OBJECT_MAP.get(key);
             if (instance == null) {
                 try {
                     instance = c.getDeclaredConstructor().newInstance();


### PR DESCRIPTION
* 将获取单例对象的 get 操作挪到同步代码块中

如果不同步的话：当某个对象还没创建时，线程 t1 的instance = null。还没有进入同步代码块时，资源被 t2抢占，t2 的 instance也为 null， 执行后续代码，实例化一个对象并放入 map 中。切回 t1 后，t1 的 instance 此时仍然为 null，t1 又会实例化一个新的对象放入 map 中。这样会导致 t1 和 t2 通过 getInstance 方法获取的有可能不是同一个对象，所以 get 对象也应当放入同步代码块中。