### PR TITLE
Update NettyRpcClient.java

### DIFF
--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
@@ -61,7 +61,7 @@ public final class NettyRpcClient implements RpcRequestTransport {
                     @Override
                     protected void initChannel(SocketChannel ch) {
                         ChannelPipeline p = ch.pipeline();
-                        // If no data is sent to the server within 15 seconds, a heartbeat request is sent
+                        // If no data is sent to the server within 5 seconds, a heartbeat request is sent
                         p.addLast(new IdleStateHandler(0, 5, 0, TimeUnit.SECONDS));
                         p.addLast(new RpcMessageEncoder());
                         p.addLast(new RpcMessageDecoder());


### PR DESCRIPTION
注释中的 IdleStateHandler 写空闲时间参数与实际值不一致。