### PR TITLE
为SPI机制增加策略枚举

### DIFF
--- a/rpc-framework-common/src/main/java/github/javaguide/enums/LoadBalanceEnum.java
+++ b/rpc-framework-common/src/main/java/github/javaguide/enums/LoadBalanceEnum.java
@@ -1,0 +1,17 @@
+package github.javaguide.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @Author xiaobiaoxu
+ * @Date 2023年02月24日 15:31
+ */
+@AllArgsConstructor
+@Getter
+public enum LoadBalanceEnum {
+
+    LOADBALANCE("loadBalance");
+
+    private final String name;
+}

--- a/rpc-framework-common/src/main/java/github/javaguide/enums/RpcRequestTransportEnum.java
+++ b/rpc-framework-common/src/main/java/github/javaguide/enums/RpcRequestTransportEnum.java
@@ -1,0 +1,18 @@
+package github.javaguide.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @Author xiaobiaoxu
+ * @Date 2023年02月24日 15:30
+ */
+@AllArgsConstructor
+@Getter
+public enum RpcRequestTransportEnum {
+
+    NETTY("netty"),
+    SOCKET("socket");
+
+    private final String name;
+}

--- a/rpc-framework-common/src/main/java/github/javaguide/enums/ServiceDiscoveryEnum.java
+++ b/rpc-framework-common/src/main/java/github/javaguide/enums/ServiceDiscoveryEnum.java
@@ -1,0 +1,17 @@
+package github.javaguide.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @Author xiaobiaoxu
+ * @Date 2023年02月24日 15:33
+ */
+@AllArgsConstructor
+@Getter
+public enum ServiceDiscoveryEnum {
+
+    ZK("zk");
+
+    private final String name;
+}

--- a/rpc-framework-common/src/main/java/github/javaguide/enums/ServiceRegistryEnum.java
+++ b/rpc-framework-common/src/main/java/github/javaguide/enums/ServiceRegistryEnum.java
@@ -1,0 +1,17 @@
+package github.javaguide.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @Author xiaobiaoxu
+ * @Date 2023年02月24日 15:30
+ */
+@AllArgsConstructor
+@Getter
+public enum ServiceRegistryEnum {
+
+    ZK("zk");
+
+    private final String name;
+}

--- a/rpc-framework-simple/src/main/java/github/javaguide/provider/impl/ZkServiceProviderImpl.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/provider/impl/ZkServiceProviderImpl.java
@@ -2,6 +2,7 @@ package github.javaguide.provider.impl;
 
 import github.javaguide.config.RpcServiceConfig;
 import github.javaguide.enums.RpcErrorMessageEnum;
+import github.javaguide.enums.ServiceRegistryEnum;
 import github.javaguide.exception.RpcException;
 import github.javaguide.extension.ExtensionLoader;
 import github.javaguide.provider.ServiceProvider;
@@ -34,7 +35,7 @@ public class ZkServiceProviderImpl implements ServiceProvider {
     public ZkServiceProviderImpl() {
         serviceMap = new ConcurrentHashMap<>();
         registeredService = ConcurrentHashMap.newKeySet();
-        serviceRegistry = ExtensionLoader.getExtensionLoader(ServiceRegistry.class).getExtension("zk");
+        serviceRegistry = ExtensionLoader.getExtensionLoader(ServiceRegistry.class).getExtension(ServiceRegistryEnum.ZK.getName());
     }
 
     @Override

--- a/rpc-framework-simple/src/main/java/github/javaguide/registry/zk/ZkServiceDiscoveryImpl.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/registry/zk/ZkServiceDiscoveryImpl.java
@@ -1,5 +1,6 @@
 package github.javaguide.registry.zk;
 
+import github.javaguide.enums.LoadBalanceEnum;
 import github.javaguide.enums.RpcErrorMessageEnum;
 import github.javaguide.exception.RpcException;
 import github.javaguide.extension.ExtensionLoader;
@@ -25,7 +26,7 @@ public class ZkServiceDiscoveryImpl implements ServiceDiscovery {
     private final LoadBalance loadBalance;
 
     public ZkServiceDiscoveryImpl() {
-        this.loadBalance = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension("loadBalance");
+        this.loadBalance = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(LoadBalanceEnum.LOADBALANCE.getName());
     }
 
     @Override

--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
@@ -3,6 +3,7 @@ package github.javaguide.remoting.transport.netty.client;
 
 import github.javaguide.enums.CompressTypeEnum;
 import github.javaguide.enums.SerializationTypeEnum;
+import github.javaguide.enums.ServiceDiscoveryEnum;
 import github.javaguide.extension.ExtensionLoader;
 import github.javaguide.factory.SingletonFactory;
 import github.javaguide.registry.ServiceDiscovery;
@@ -68,7 +69,7 @@ public final class NettyRpcClient implements RpcRequestTransport {
                         p.addLast(new NettyRpcClientHandler());
                     }
                 });
-        this.serviceDiscovery = ExtensionLoader.getExtensionLoader(ServiceDiscovery.class).getExtension("zk");
+        this.serviceDiscovery = ExtensionLoader.getExtensionLoader(ServiceDiscovery.class).getExtension(ServiceDiscoveryEnum.ZK.getName());
         this.unprocessedRequests = SingletonFactory.getInstance(UnprocessedRequests.class);
         this.channelProvider = SingletonFactory.getInstance(ChannelProvider.class);
     }

--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/socket/SocketRpcClient.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/socket/SocketRpcClient.java
@@ -1,5 +1,6 @@
 package github.javaguide.remoting.transport.socket;
 
+import github.javaguide.enums.ServiceDiscoveryEnum;
 import github.javaguide.exception.RpcException;
 import github.javaguide.extension.ExtensionLoader;
 import github.javaguide.registry.ServiceDiscovery;
@@ -26,7 +27,7 @@ public class SocketRpcClient implements RpcRequestTransport {
     private final ServiceDiscovery serviceDiscovery;
 
     public SocketRpcClient() {
-        this.serviceDiscovery = ExtensionLoader.getExtensionLoader(ServiceDiscovery.class).getExtension("zk");
+        this.serviceDiscovery = ExtensionLoader.getExtensionLoader(ServiceDiscovery.class).getExtension(ServiceDiscoveryEnum.ZK.getName());
     }
 
     @Override

--- a/rpc-framework-simple/src/main/java/github/javaguide/spring/SpringBeanPostProcessor.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/spring/SpringBeanPostProcessor.java
@@ -3,6 +3,7 @@ package github.javaguide.spring;
 import github.javaguide.annotation.RpcReference;
 import github.javaguide.annotation.RpcService;
 import github.javaguide.config.RpcServiceConfig;
+import github.javaguide.enums.RpcRequestTransportEnum;
 import github.javaguide.extension.ExtensionLoader;
 import github.javaguide.factory.SingletonFactory;
 import github.javaguide.provider.ServiceProvider;
@@ -32,7 +33,7 @@ public class SpringBeanPostProcessor implements BeanPostProcessor {
 
     public SpringBeanPostProcessor() {
         this.serviceProvider = SingletonFactory.getInstance(ZkServiceProviderImpl.class);
-        this.rpcClient = ExtensionLoader.getExtensionLoader(RpcRequestTransport.class).getExtension("netty");
+        this.rpcClient = ExtensionLoader.getExtensionLoader(RpcRequestTransport.class).getExtension(RpcRequestTransportEnum.NETTY.getName());
     }
 
     @SneakyThrows


### PR DESCRIPTION
guide哥你好，之前看了你开源rpc-guide项目收益匪浅，也在你星球生活了一段时间了，最近冲浪的时候看到策略者模式的一篇文章，后面想到SPI机制也是策略者模式，同时发现项目中用于SPI机制的文件有些没有对应的枚举类，对于SPI机制的每一个文件，我们都需要维护一个策略枚举，让别人知道你当前具有哪些策略，方便其他开发者在使用时进行查看，当然他也可以去配置文件中查看，但是你编程过程经常去翻配置文件，然后填写对应的字符串key，总让人觉得很奇怪，而且如果配置文件里面的值需要进行修改，还得手动全局替换用到该修改值的地方，所以我为SPI文件加了几个枚举类，也修改了代码中直接使用字符串的地方，运行测试都没问题，提交了一个PR，如有错误或者不规范的地方请guide哥指点，再次对duige哥开源的项目表示感谢