### PR TITLE
优化服务器端Handler共享机制并修复Protostuff序列化线程安全问题

### DIFF
--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/client/NettyRpcClient.java
@@ -12,8 +12,8 @@ import github.javaguide.remoting.dto.RpcMessage;
 import github.javaguide.remoting.dto.RpcRequest;
 import github.javaguide.remoting.dto.RpcResponse;
 import github.javaguide.remoting.transport.RpcRequestTransport;
-import github.javaguide.remoting.transport.netty.codec.RpcMessageDecoder;
-import github.javaguide.remoting.transport.netty.codec.RpcMessageEncoder;
+import github.javaguide.remoting.transport.netty.codec.RpcMessageCodec;
+import github.javaguide.remoting.transport.netty.codec.RpcMessageFrameDecoder;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -47,6 +47,7 @@ public final class NettyRpcClient implements RpcRequestTransport {
     public NettyRpcClient() {
         // initialize resources such as EventLoopGroup, Bootstrap
         eventLoopGroup = new NioEventLoopGroup();
+        RpcMessageCodec rpcMessageCodec = new RpcMessageCodec();
         bootstrap = new Bootstrap();
         bootstrap.group(eventLoopGroup)
                 .channel(NioSocketChannel.class)
@@ -60,8 +61,9 @@ public final class NettyRpcClient implements RpcRequestTransport {
                         ChannelPipeline p = ch.pipeline();
                         // If no data is sent to the server within 15 seconds, a heartbeat request is sent
                         p.addLast(new IdleStateHandler(0, 5, 0, TimeUnit.SECONDS));
-                        p.addLast(new RpcMessageEncoder());
-                        p.addLast(new RpcMessageDecoder());
+                        // RPCMessageFrame  解码器
+                        p.addLast(new RpcMessageFrameDecoder());
+                        p.addLast(rpcMessageCodec);
                         p.addLast(new NettyRpcClientHandler());
                     }
                 });

--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/codec/RpcMessageCodec.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/codec/RpcMessageCodec.java
@@ -1,0 +1,167 @@
+package github.javaguide.remoting.transport.netty.codec;
+
+import github.javaguide.compress.Compress;
+import github.javaguide.enums.CompressTypeEnum;
+import github.javaguide.enums.SerializationTypeEnum;
+import github.javaguide.extension.ExtensionLoader;
+import github.javaguide.remoting.constants.RpcConstants;
+import github.javaguide.remoting.dto.RpcMessage;
+import github.javaguide.remoting.dto.RpcRequest;
+import github.javaguide.remoting.dto.RpcResponse;
+import github.javaguide.serialize.Serializer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageCodec;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static github.javaguide.remoting.constants.RpcConstants.HEARTBEAT_REQUEST_TYPE;
+import static github.javaguide.remoting.constants.RpcConstants.HEARTBEAT_RESPONSE_TYPE;
+
+/**
+ * @ClassName RpcMessageCodec
+ * @Description 可共享的 RPCMessage 编解码器
+ * @Author jiangyang1556
+ * @Date 2025/9/29 17:04
+ * @Version 1.0
+ **/
+@Slf4j
+@ChannelHandler.Sharable
+public class RpcMessageCodec extends MessageToMessageCodec<ByteBuf, RpcMessage> {
+    private static final AtomicInteger ATOMIC_INTEGER = new AtomicInteger(0);
+    /**
+     * RPC Message -> ByteBuf
+     */
+    @Override
+    protected void encode(ChannelHandlerContext ctx, RpcMessage rpcMessage, List<Object> list) throws Exception {
+        /**
+         * request header 16bytes
+         */
+        ByteBuf out = ctx.alloc().buffer();
+        // magic number 4 byte
+        out.writeBytes(RpcConstants.MAGIC_NUMBER);
+        // version 1 byte
+        out.writeByte(RpcConstants.VERSION);
+        // full length 占位
+        out.writeInt(0);
+        // message type 1byte
+        out.writeByte(rpcMessage.getMessageType());
+        // serialize 1 byte
+        out.writeByte(rpcMessage.getCodec());
+        // compress 1byte
+        out.writeByte(CompressTypeEnum.GZIP.getCode());
+        // requestId 4 byte
+        out.writeInt(ATOMIC_INTEGER.getAndIncrement());
+        /**
+         * request body
+         */
+        byte[] bodyBytes = null;
+        int fullLength = RpcConstants.HEAD_LENGTH;
+        if(rpcMessage.getMessageType() != HEARTBEAT_REQUEST_TYPE && rpcMessage.getMessageType() != HEARTBEAT_RESPONSE_TYPE) {
+            String serialize = SerializationTypeEnum.getName(rpcMessage.getCodec());
+            Serializer serializer = ExtensionLoader.getExtensionLoader(Serializer.class).getExtension(serialize);
+            bodyBytes = serializer.serialize(rpcMessage.getData());
+            Compress compress = ExtensionLoader.getExtensionLoader(Compress.class).getExtension(CompressTypeEnum.getName(rpcMessage.getCompress()));
+            log.debug("before compress request body size: [{}]", bodyBytes.length);
+            bodyBytes = compress.compress(bodyBytes);
+            log.debug("after compress request body size: [{}]", bodyBytes.length);
+            // 加上请求体长度
+            fullLength += bodyBytes.length;
+        }
+        if(bodyBytes != null) {
+            out.writeBytes(bodyBytes);
+        }
+        // 写入包的长度字段
+        int writeIndex = out.writerIndex();
+        out.writerIndex(RpcConstants.MAGIC_NUMBER.length + 1);
+        out.writeInt(fullLength);
+        out.writerIndex(writeIndex);
+
+        list.add(out);
+    }
+    /**
+     * ByteBuf -> RPC Message
+     */
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> list) throws Exception {
+        /**
+         * 请求头检查
+         */
+        checkMagicNumber(in);
+        checkVersion(in);
+        /**
+         * 处理请求体
+         */
+        int fullLength = in.readInt();
+
+        byte messageType = in.readByte();
+        byte codecType = in.readByte();
+        byte compressType = in.readByte();
+        int requestId = in.readInt();
+
+        RpcMessage rpcMessage = new RpcMessage();
+        rpcMessage.setMessageType(messageType);
+        rpcMessage.setCodec(codecType);
+        rpcMessage.setCompress(compressType);
+        rpcMessage.setRequestId(requestId);
+
+        if (messageType == HEARTBEAT_REQUEST_TYPE) {
+            rpcMessage.setData(RpcConstants.PING);
+            list.add(rpcMessage);
+            return;
+        }
+        if (messageType == HEARTBEAT_RESPONSE_TYPE) {
+            rpcMessage.setData(RpcConstants.PONG);
+            list.add(rpcMessage);
+            return;
+        }
+        /**
+         * rpcMessage data
+         */
+        int bodyLength = fullLength - RpcConstants.HEAD_LENGTH;
+        if (bodyLength > 0) {
+            byte[] bodyBytes = new byte[bodyLength];
+            in.readBytes(bodyBytes);
+            // decompress the bytes
+            String compressName = CompressTypeEnum.getName(compressType);
+            Compress compress = ExtensionLoader.getExtensionLoader(Compress.class).getExtension(compressName);
+            log.debug("before decompress request body size: [{}]", bodyBytes.length);
+            bodyBytes = compress.decompress(bodyBytes);
+            log.debug("after decompress request body size: [{}]", bodyBytes.length);
+            // deserialize
+            String codecName = SerializationTypeEnum.getName(rpcMessage.getCodec());
+            log.debug("codec name: [{}] ", codecName);
+            Serializer serializer = ExtensionLoader.getExtensionLoader(Serializer.class).getExtension(codecName);
+            if (messageType == RpcConstants.REQUEST_TYPE) {
+                RpcRequest rpcRequest = serializer.deserialize(bodyBytes, RpcRequest.class);
+                rpcMessage.setData(rpcRequest);
+            } else {
+                RpcResponse rpcRequest = serializer.deserialize(bodyBytes, RpcResponse.class);
+                rpcMessage.setData(rpcRequest);
+            }
+        }
+        list.add(rpcMessage);
+    }
+
+    private void checkVersion(ByteBuf in) {
+        byte version = in.readByte();
+        if (version != RpcConstants.VERSION) {
+            throw new RuntimeException("协议版本不匹配" + version);
+        }
+    }
+
+    private void checkMagicNumber(ByteBuf in) {
+        int len = RpcConstants.MAGIC_NUMBER.length;
+        byte[] tmp = new byte[len];
+        in.readBytes(tmp);
+        for (int i = 0; i < len; i++) {
+            if (tmp[i] != RpcConstants.MAGIC_NUMBER[i]) {
+                throw new IllegalArgumentException("未知魔数: " + Arrays.toString(tmp));
+            }
+        }
+    }
+}

--- a/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/codec/RpcMessageFrameDecoder.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/remoting/transport/netty/codec/RpcMessageFrameDecoder.java
@@ -1,0 +1,17 @@
+package github.javaguide.remoting.transport.netty.codec;
+
+import github.javaguide.remoting.constants.RpcConstants;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+
+/**
+ * @ClassName RpcMessageFrameDecoder
+ * @Description RPCMessageFrame解析器 不能共享
+ * @Author jiangyang1556
+ * @Date 2025/9/28 9:36
+ * @Version 1.0
+ **/
+public class RpcMessageFrameDecoder extends LengthFieldBasedFrameDecoder {
+    public RpcMessageFrameDecoder() {
+        super(RpcConstants.MAX_FRAME_LENGTH, 5, 4, -9, 0);
+    }
+}

--- a/rpc-framework-simple/src/main/java/github/javaguide/serialize/protostuff/ProtostuffSerializer.java
+++ b/rpc-framework-simple/src/main/java/github/javaguide/serialize/protostuff/ProtostuffSerializer.java
@@ -13,21 +13,26 @@ import io.protostuff.runtime.RuntimeSchema;
 public class ProtostuffSerializer implements Serializer {
 
     /**
-     * Avoid re applying buffer space every time serialization
+     * 使用 ThreadLocal 为每个线程分配独立的 LinkedBuffer 实例。
+     * <p>
+     * 由于 LinkedBuffer 在多线程环境下是非线程安全的，因此通过 ThreadLocal
+     * 确保每个线程都有自己专属的缓冲区，避免并发访问导致的数据竞争或序列化异常
+     * 线程管理的多个channel调用序列化算法是安全的
      */
-    private static final LinkedBuffer BUFFER = LinkedBuffer.allocate(LinkedBuffer.DEFAULT_BUFFER_SIZE);
+    private static final ThreadLocal<LinkedBuffer> BUFFER =
+            ThreadLocal.withInitial(() -> LinkedBuffer.allocate(LinkedBuffer.DEFAULT_BUFFER_SIZE));
 
     @Override
     public byte[] serialize(Object obj) {
         Class<?> clazz = obj.getClass();
         Schema schema = RuntimeSchema.getSchema(clazz);
-        byte[] bytes;
+        // 每个线程第一次访问LinkedBuffer时才会创建ThreadLocal对象
+        LinkedBuffer buffer = BUFFER.get();
         try {
-            bytes = ProtostuffIOUtil.toByteArray(obj, schema, BUFFER);
+            return ProtostuffIOUtil.toByteArray(obj, schema, buffer);
         } finally {
-            BUFFER.clear();
+            buffer.clear();// 清空复用
         }
-        return bytes;
     }
 
     @Override


### PR DESCRIPTION
1. 最小化不可共享的Handler Unit，实现服务器端Handler在Channel之间的安全共享。
2. 将RPCMessage帧解析与RPCMessage编解码逻辑解耦，增强模块职责清晰度。
3. 修复Protostuff序列化算法的线程安全问题，通过ThreadLocal为每个线程分配独立缓冲区，避免并发访问引发的数据竞争和序列化异常。
**MAT 分析结果显示**：在多 Client 场景下，Handler 共享显著减少了对象实例数量和堆内存占用，从而降低了服务器的内存开销和 GC 压力。
<img width="635" height="129" alt="output" src="https://github.com/user-attachments/assets/f9fd5d48-a68d-413d-8246-7ee6ee41f37d" />